### PR TITLE
OP-5020: Add optional exit price to addressUpdateSchema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@electra.finance/sdk",
-  "version": "0.2.11-rc0",
+  "version": "0.2.11-rc1",
   "description": "Electra finance SDK",
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@electra.finance/sdk",
-  "version": "0.2.10",
+  "version": "0.2.11-rc0",
   "description": "Electra finance SDK",
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",

--- a/src/services/Aggregator/ws/schemas/addressUpdateSchema.ts
+++ b/src/services/Aggregator/ws/schemas/addressUpdateSchema.ts
@@ -96,7 +96,7 @@ export const fullOrderSchema = z.object({
   t: z.number(), // update time
   lv: z.number().optional(), // leverage
   roi: z.number().optional(), // ROI%
-  ep: z.number().optional(), // exit price
+  ep: z.number().optional(), // entry price
   c: subOrderSchema.array(), // sub orders (content)
 
   // CFD only
@@ -129,7 +129,7 @@ export const fullOrderSchema = z.object({
   realizedPnL: o.rpnl,
   leverage: o.lv,
   roi: o.roi,
-  exitPrice: o.ep,
+  entryPrice: o.ep,
   subOrders: getTransformedSubOrders(o.c),
 }));
 

--- a/src/services/Aggregator/ws/schemas/addressUpdateSchema.ts
+++ b/src/services/Aggregator/ws/schemas/addressUpdateSchema.ts
@@ -96,6 +96,7 @@ export const fullOrderSchema = z.object({
   t: z.number(), // update time
   lv: z.number().optional(), // leverage
   roi: z.number().optional(), // ROI%
+  ep: z.number().optional(), // exit price
   c: subOrderSchema.array(), // sub orders (content)
 
   // CFD only
@@ -128,6 +129,7 @@ export const fullOrderSchema = z.object({
   realizedPnL: o.rpnl,
   leverage: o.lv,
   roi: o.roi,
+  exitPrice: o.ep,
   subOrders: getTransformedSubOrders(o.c),
 }));
 


### PR DESCRIPTION
The addressUpdateSchema used in the Aggregator service has been updated to include an optional 'exit price' field. This has been added to improve the granularity and accuracy of trade management, providing more data for transactional analysis.